### PR TITLE
fix: Mobile Style

### DIFF
--- a/app/components/ui/servers/ServerCard.vue
+++ b/app/components/ui/servers/ServerCard.vue
@@ -43,7 +43,7 @@
       </div>
 
       <div>
-        <p class="text-xs line-clamp-2 mb-3 text-white/80 h-8 overflow-hidden">
+        <p class="text-xs line-clamp-2 mb-3 text-white/80">
           <span v-if="loadingDescription" class="opacity-50">Loading...</span>
           <span v-else>{{ description || instance.id }}</span>
         </p>

--- a/app/components/ui/servers/ServerCard.vue
+++ b/app/components/ui/servers/ServerCard.vue
@@ -19,48 +19,54 @@
     </div>
 
     <div
-      :class="view === 'list' ? 'absolute inset-0 z-10 p-4 flex flex-col justify-end' : 'absolute inset-0 p-3 flex flex-col justify-end sm:p-4'">
+      :class="view === 'list' ? 'absolute inset-0 z-10 p-4 flex flex-col justify-end gap-2' : 'absolute inset-0 p-3 flex flex-col justify-between lg:justify-end gap-2 sm:p-4'">
+
       <div>
-        <div class="flex items-center gap-2.5 mb-2">
+        <div class="flex flex-col items-start gap-2 mb-0">
           <img v-if="fetchedIcon" :src="fetchedIcon" class="w-8 h-8 bg-white/10 backdrop-blur-sm shadow-sm" alt=""
             @error="fetchedIcon = null" />
           <div v-else
             class="w-8 h-8 bg-primary flex items-center justify-center text-white text-sm font-bold shadow-sm">
             {{ (instance.node_name || instance.id).charAt(0).toUpperCase() }}
           </div>
-          <div class="flex-1 min-w-0">
+          <div class="w-full min-w-0">
             <h3 class="font-bold truncate transition-colors text-white group-hover:text-primary text-sm sm:text-base">
               {{ instance.node_name || instance.id }}
             </h3>
-            <p class="text-[10px] font-mono text-white/70">
-              {{ instance.id }} (v{{ instance.version }})
-            </p>
+            <div class="text-[10px] font-mono text-white/70 flex flex-wrap gap-x-1 items-baseline w-full">
+              <span class="truncate max-w-full">{{ instance.id }}</span>
+              <span class="truncate max-w-full opacity-80 decoration-dotted whitespace-nowrap">(v{{ instance.version
+              }})</span>
+            </div>
           </div>
         </div>
-        <p class="text-xs line-clamp-2 mb-3 text-white/80">
+      </div>
+
+      <div>
+        <p class="text-xs line-clamp-2 mb-3 text-white/80 h-8 overflow-hidden">
           <span v-if="loadingDescription" class="opacity-50">Loading...</span>
           <span v-else>{{ description || instance.id }}</span>
         </p>
-      </div>
 
-      <div class="flex flex-wrap items-center gap-x-3 gap-y-1 text-[10px] font-medium text-white/60">
-        <span class="flex items-center gap-1" title="Users">
-          <Icon name="lucide:users" class="w-3.5 h-3.5" />
-          {{ formatNumber(instance.users_count) }}
-        </span>
-        <span class="flex items-center gap-1" title="Notes">
-          <Icon name="lucide:file-text" class="w-3.5 h-3.5" />
-          {{ formatNumber(instance.notes_count) }}
-        </span>
-        <span v-if="instance.language" class="flex items-center gap-1" title="Language">
-          <Icon name="lucide:globe" class="w-3.5 h-3.5" />
-          {{ getLanguageName(instance.language) }}
-        </span>
-        <span class="flex items-center gap-1" :class="instance.is_alive ? 'text-green-500' : 'text-red-500'"
-          :title="instance.is_alive ? 'Online' : 'Offline'">
-          <span class="w-1.5 h-1.5 rounded-full" :class="instance.is_alive ? 'bg-green-500' : 'bg-red-500'"></span>
-          {{ instance.is_alive ? 'Online' : 'Offline' }}
-        </span>
+        <div class="flex flex-wrap items-center gap-x-3 gap-y-1 text-[10px] font-medium text-white/60">
+          <span class="flex items-center gap-1" title="Users">
+            <Icon name="lucide:users" class="w-3.5 h-3.5" />
+            {{ formatNumber(instance.users_count) }}
+          </span>
+          <span class="flex items-center gap-1" title="Notes">
+            <Icon name="lucide:file-text" class="w-3.5 h-3.5" />
+            {{ formatNumber(instance.notes_count) }}
+          </span>
+          <span v-if="instance.language" class="flex items-center gap-1" title="Language">
+            <Icon name="lucide:globe" class="w-3.5 h-3.5" />
+            {{ getLanguageName(instance.language) }}
+          </span>
+          <span class="flex items-center gap-1" :class="instance.is_alive ? 'text-green-500' : 'text-red-500'"
+            :title="instance.is_alive ? 'Online' : 'Offline'">
+            <span class="w-1.5 h-1.5 rounded-full" :class="instance.is_alive ? 'bg-green-500' : 'bg-red-500'"></span>
+            {{ instance.is_alive ? 'Online' : 'Offline' }}
+          </span>
+        </div>
       </div>
     </div>
     <div

--- a/app/components/ui/servers/ServerCard.vue
+++ b/app/components/ui/servers/ServerCard.vue
@@ -5,7 +5,8 @@
 
     <div class="relative overflow-hidden"
       :class="view === 'list' ? 'absolute inset-0 w-full h-full' : 'aspect-[10/12] lg:aspect-[4/3] w-full'">
-      <img v-if="fetchedBanner" loading="lazy" :src="fetchedBanner" :alt="instance.node_name || ''"
+      <img v-if="fetchedBanner" loading="lazy" :src="fetchedBanner"
+        :alt="instance.node_name || instance.id || 'Server banner'"
         class="absolute inset-0 h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
         @error="fetchedBanner = null" />
       <div v-else class="absolute inset-0 bg-neutral-800 flex items-center justify-center">

--- a/app/components/ui/servers/ServerCard.vue
+++ b/app/components/ui/servers/ServerCard.vue
@@ -1,12 +1,13 @@
 <template>
   <NuxtLink :to="`https://${instance.id}`" target="_blank" rel="noopener noreferrer"
     class="group relative block overflow-hidden bg-neutral-100 dark:bg-neutral-900 transition-all duration-300 hover:scale-[1.005] focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none"
-    :class="view === 'list' ? 'h-40' : ''">
+    :class="view === 'list' ? 'h-48' : ''">
 
     <div class="relative overflow-hidden"
-      :class="view === 'list' ? 'absolute inset-0 w-full h-full' : 'aspect-[4/3] w-full'">
+      :class="view === 'list' ? 'absolute inset-0 w-full h-full' : 'aspect-[10/12] lg:aspect-[4/3] w-full'">
       <img v-if="fetchedBanner" loading="lazy" :src="fetchedBanner" :alt="instance.node_name || ''"
-        class="absolute inset-0 h-full w-full object-cover transition-transform duration-500 group-hover:scale-105" />
+        class="absolute inset-0 h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
+        @error="fetchedBanner = null" />
       <div v-else class="absolute inset-0 bg-neutral-800 flex items-center justify-center">
         <div class="text-neutral-600 text-center">
           <Icon name="lucide:image" class="w-12 h-12 mx-auto mb-2" />
@@ -18,16 +19,17 @@
     </div>
 
     <div
-      :class="view === 'list' ? 'absolute inset-0 z-10 p-4 flex flex-col justify-end' : 'absolute inset-0 p-4 flex flex-col justify-end'">
+      :class="view === 'list' ? 'absolute inset-0 z-10 p-4 flex flex-col justify-end' : 'absolute inset-0 p-3 flex flex-col justify-end sm:p-4'">
       <div>
         <div class="flex items-center gap-2.5 mb-2">
-          <img v-if="fetchedIcon" :src="fetchedIcon" class="w-8 h-8 bg-white/10 backdrop-blur-sm shadow-sm" alt="" />
+          <img v-if="fetchedIcon" :src="fetchedIcon" class="w-8 h-8 bg-white/10 backdrop-blur-sm shadow-sm" alt=""
+            @error="fetchedIcon = null" />
           <div v-else
             class="w-8 h-8 bg-primary flex items-center justify-center text-white text-sm font-bold shadow-sm">
             {{ (instance.node_name || instance.id).charAt(0).toUpperCase() }}
           </div>
           <div class="flex-1 min-w-0">
-            <h3 class="text-base font-bold truncate transition-colors text-white group-hover:text-primary">
+            <h3 class="font-bold truncate transition-colors text-white group-hover:text-primary text-sm sm:text-base">
               {{ instance.node_name || instance.id }}
             </h3>
             <p class="text-[10px] font-mono text-white/70">
@@ -41,7 +43,7 @@
         </p>
       </div>
 
-      <div class="flex items-center gap-3 text-[10px] font-medium text-white/60">
+      <div class="flex flex-wrap items-center gap-x-3 gap-y-1 text-[10px] font-medium text-white/60">
         <span class="flex items-center gap-1" title="Users">
           <Icon name="lucide:users" class="w-3.5 h-3.5" />
           {{ formatNumber(instance.users_count) }}

--- a/app/components/ui/servers/ServerCard.vue
+++ b/app/components/ui/servers/ServerCard.vue
@@ -1,10 +1,10 @@
 <template>
   <NuxtLink :to="`https://${instance.id}`" target="_blank" rel="noopener noreferrer"
     class="group relative block overflow-hidden bg-neutral-100 dark:bg-neutral-900 transition-all duration-300 hover:scale-[1.005] focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none"
-    :class="view === 'list' ? 'flex flex-row h-32' : ''">
+    :class="view === 'list' ? 'h-40' : ''">
 
     <div class="relative overflow-hidden"
-      :class="view === 'list' ? 'aspect-square h-full w-24 sm:w-auto flex-shrink-0' : 'aspect-[4/3] w-full'">
+      :class="view === 'list' ? 'absolute inset-0 w-full h-full' : 'aspect-[4/3] w-full'">
       <img v-if="fetchedBanner" loading="lazy" :src="fetchedBanner" :alt="instance.node_name || ''"
         class="absolute inset-0 h-full w-full object-cover transition-transform duration-500 group-hover:scale-105" />
       <div v-else class="absolute inset-0 bg-neutral-800 flex items-center justify-center">
@@ -12,12 +12,13 @@
           <Icon name="lucide:image" class="w-12 h-12 mx-auto mb-2" />
         </div>
       </div>
-      <div v-if="view !== 'list'" class="absolute inset-0 bg-gradient-to-t from-black/90 via-black/40 to-transparent">
+      <div :class="view === 'list' ? '' : ''"
+        class="absolute inset-0 bg-gradient-to-t from-black/90 via-black/40 to-transparent">
       </div>
     </div>
 
     <div
-      :class="view === 'list' ? 'flex-1 p-4 flex flex-col justify-between' : 'absolute inset-0 p-4 flex flex-col justify-end'">
+      :class="view === 'list' ? 'absolute inset-0 z-10 p-4 flex flex-col justify-end' : 'absolute inset-0 p-4 flex flex-col justify-end'">
       <div>
         <div class="flex items-center gap-2.5 mb-2">
           <img v-if="fetchedIcon" :src="fetchedIcon" class="w-8 h-8 bg-white/10 backdrop-blur-sm shadow-sm" alt="" />
@@ -26,25 +27,21 @@
             {{ (instance.node_name || instance.id).charAt(0).toUpperCase() }}
           </div>
           <div class="flex-1 min-w-0">
-            <h3 class="text-base font-bold truncate transition-colors"
-              :class="view === 'list' ? 'text-neutral-900 dark:text-white group-hover:text-primary' : 'text-white group-hover:text-primary'">
+            <h3 class="text-base font-bold truncate transition-colors text-white group-hover:text-primary">
               {{ instance.node_name || instance.id }}
             </h3>
-            <p class="text-[10px] font-mono"
-              :class="view === 'list' ? 'text-neutral-500 dark:text-neutral-400' : 'text-white/70'">
+            <p class="text-[10px] font-mono text-white/70">
               {{ instance.id }} (v{{ instance.version }})
             </p>
           </div>
         </div>
-        <p class="text-xs line-clamp-2 mb-3"
-          :class="view === 'list' ? 'text-neutral-600 dark:text-neutral-300' : 'text-white/80'">
+        <p class="text-xs line-clamp-2 mb-3 text-white/80">
           <span v-if="loadingDescription" class="opacity-50">Loading...</span>
           <span v-else>{{ description || instance.id }}</span>
         </p>
       </div>
 
-      <div class="flex items-center gap-3 text-[10px] font-medium"
-        :class="view === 'list' ? 'text-neutral-500 dark:text-neutral-400' : 'text-white/60'">
+      <div class="flex items-center gap-3 text-[10px] font-medium text-white/60">
         <span class="flex items-center gap-1" title="Users">
           <Icon name="lucide:users" class="w-3.5 h-3.5" />
           {{ formatNumber(instance.users_count) }}

--- a/app/components/ui/servers/ServerCard.vue
+++ b/app/components/ui/servers/ServerCard.vue
@@ -13,8 +13,7 @@
           <Icon name="lucide:image" class="w-12 h-12 mx-auto mb-2" />
         </div>
       </div>
-      <div :class="view === 'list' ? '' : ''"
-        class="absolute inset-0 bg-gradient-to-t from-black/90 via-black/40 to-transparent">
+      <div class="absolute inset-0 bg-gradient-to-t from-black/90 via-black/40 to-transparent">
       </div>
     </div>
 

--- a/app/pages/servers.vue
+++ b/app/pages/servers.vue
@@ -295,7 +295,7 @@ useJsonld(() => ({
 
         <!-- Grid/List Container -->
         <div :class="v_view === 'grid'
-          ? 'grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 gap-3 lg:gap-4'
+          ? 'grid grid-cols-2 sm:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 gap-3 lg:gap-4'
           : 'flex flex-col gap-3'">
 
           <!-- Server cards -->

--- a/app/utils/constants.ts
+++ b/app/utils/constants.ts
@@ -1,5 +1,5 @@
 export const PAGE_SIZE = 30;
-export const STORAGE_KEY = 'miHub_server_finder';
+export const STORAGE_KEY = 'miHub_server_finder_v2';
 
 export const SORT_API_MAP: Record<SortField, string> = {
   recommendedScore: 'recommended',

--- a/app/utils/constants.ts
+++ b/app/utils/constants.ts
@@ -1,5 +1,5 @@
 export const PAGE_SIZE = 30;
-export const STORAGE_KEY = 'miHub_server_finder_v2';
+export const STORAGE_KEY = 'miHub_server_finder';
 
 export const SORT_API_MAP: Record<SortField, string> = {
   recommendedScore: 'recommended',


### PR DESCRIPTION
`/servers`におけるモバイル時のグリッド/リスト表示を改善

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * 画像読み込み失敗時のハンドリング強化：壊れたバナー／アイコンは安全にクリアしてフォールバックを維持

* **改善**
  * サーバーカードのレイアウトを全ビューで一貫化（配置・オーバーレイ・間隔の調整、アスペクト制御の最適化）
  * タイトル・メタ情報・説明の表示を統一・安定化（省スペース化、トランケーション、読み込み状態の保持）
  * 小画面でのサーバーグリッド密度を向上（1列→2列）

* **雑務**
  * ローカル保存キーを更新し互換性を調整

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->